### PR TITLE
Feat limit attempt on login with configuration

### DIFF
--- a/src/main/java/io/shelang/aghab/exception/MaxLoginRetry.java
+++ b/src/main/java/io/shelang/aghab/exception/MaxLoginRetry.java
@@ -1,0 +1,13 @@
+package io.shelang.aghab.exception;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+public class MaxLoginRetry extends WebApplicationException {
+  private static final String DEFAULT_MESSAGE =
+      "You Entered your password wrong, you banned for at least 2 hours.";
+
+  public MaxLoginRetry() {
+    super(DEFAULT_MESSAGE, Response.Status.NOT_ACCEPTABLE);
+  }
+}

--- a/src/main/java/io/shelang/aghab/service/ratelimiter/RateLimiter.java
+++ b/src/main/java/io/shelang/aghab/service/ratelimiter/RateLimiter.java
@@ -1,0 +1,5 @@
+package io.shelang.aghab.service.ratelimiter;
+
+public interface RateLimiter {
+  void handleLoginAttempt(String username);
+}

--- a/src/main/java/io/shelang/aghab/service/ratelimiter/RateLimiterImpl.java
+++ b/src/main/java/io/shelang/aghab/service/ratelimiter/RateLimiterImpl.java
@@ -1,0 +1,38 @@
+package io.shelang.aghab.service.ratelimiter;
+
+import io.quarkus.redis.datasource.RedisDataSource;
+import io.quarkus.redis.datasource.keys.KeyCommands;
+import io.quarkus.redis.datasource.string.StringCommands;
+import io.shelang.aghab.exception.MaxLoginRetry;
+import java.time.Duration;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@ApplicationScoped
+public class RateLimiterImpl implements RateLimiter {
+
+  private final StringCommands<String, Long> countCommands;
+  private final KeyCommands<String> keyCommands;
+  @ConfigProperty(name = "app.login.attempt.block.duration", defaultValue = "2h")
+  Duration loginAttemptBlockDuration;
+  @ConfigProperty(name = "app.login.attempt.max.count", defaultValue = "6")
+  int loginAttemptMaxCount;
+
+  @Inject
+  @SuppressWarnings("CdiInjectionPointsInspection")
+  public RateLimiterImpl(RedisDataSource ds) {
+    this.countCommands = ds.string(Long.class);
+    this.keyCommands = ds.key();
+  }
+
+  public void
+  handleLoginAttempt(String username) {
+    var key = "login:attempt:" + username;
+    long incr = countCommands.incr(key);
+    if (incr > loginAttemptMaxCount) {
+      throw new MaxLoginRetry();
+    }
+    keyCommands.expire(key, loginAttemptBlockDuration.toSeconds());
+  }
+}

--- a/src/main/java/io/shelang/aghab/service/user/impl/AuthServiceImpl.java
+++ b/src/main/java/io/shelang/aghab/service/user/impl/AuthServiceImpl.java
@@ -3,6 +3,7 @@ package io.shelang.aghab.service.user.impl;
 import io.shelang.aghab.repository.UserRepository;
 import io.shelang.aghab.role.Roles;
 import io.shelang.aghab.service.dto.LoginDTO;
+import io.shelang.aghab.service.ratelimiter.RateLimiter;
 import io.shelang.aghab.service.user.AuthService;
 import io.shelang.aghab.service.user.TokenService;
 import javax.annotation.security.RolesAllowed;
@@ -19,9 +20,12 @@ public class AuthServiceImpl implements AuthService {
   UserRepository userRepository;
   @Inject
   TokenService tokenService;
+  @Inject
+  RateLimiter rateLimiter;
 
   @Override
   public LoginDTO login(String username, String password) {
+    rateLimiter.handleLoginAttempt(username);
     var user = userRepository.findByUsername(username).orElseThrow(NotFoundException::new);
     if (!BCrypt.checkpw(password, user.getPassword())) {
       throw new BadRequestException("Wrong password");


### PR DESCRIPTION
Now service can limit the number of attempts per username and block them for a period of time.

There are two new configs:

`app.login.attempt.max.count` and `app.login.attempt.block.duration`