### PR TITLE
Fix (Quartz) Update all job that was trying to be run by fucking wrong class name! 

### DIFF
--- a/src/main/resources/db/migration/V1.7.1__Fix_Quarkus_Upgrade_Quartz.sql
+++ b/src/main/resources/db/migration/V1.7.1__Fix_Quarkus_Upgrade_Quartz.sql
@@ -1,0 +1,4 @@
+-- WTF!
+UPDATE qrtz_job_details
+SET job_class_name='io.quarkus.quartz.runtime.QuartzSchedulerImpl$InvokerJob'
+WHERE job_class_name='io.quarkus.quartz.runtime.QuartzScheduler$InvokerJob';


### PR DESCRIPTION
Problem:

Due to this error, you were not able to run the backend with the expiration feature. `Quartz` keep a fucking class name in the database that has been changed by the Quarkus team in a new release, and causes the application not to work properly.

This change affects old instance migration. The fresh application works fine.

```text
io.quarkus.runtime.Application Failed to start application (with profile prod): java.lang.ClassNotFoundException: io.quarkus.quartz.runtime.QuartzScheduler$InvokerJob
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:521)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:115)
	at io.quarkus.bootstrap.runner.RunnerClassLoader.loadClass(RunnerClassLoader.java:65)
	at org.quartz.simpl.InitThreadContextClassLoadHelper.loadClass(InitThreadContextClassLoadHelper.java:72)
	at org.quartz.simpl.InitThreadContextClassLoadHelper.loadClass(InitThreadContextClassLoadHelper.java:78)
	at org.quartz.impl.jdbcjobstore.StdJDBCDelegate.selectJobForTrigger(StdJDBCDelegate.java:1662)
	at org.quartz.impl.jdbcjobstore.StdJDBCDelegate.selectJobForTrigger(StdJDBCDelegate.java:1628)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.replaceTrigger(JobStoreSupport.java:1489)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport$11.execute(JobStoreSupport.java:1478)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.executeInNonManagedTXLock(JobStoreSupport.java:3864)
	at org.quartz.impl.jdbcjobstore.JobStoreTX.executeInLock(JobStoreTX.java:93)
	at org.quartz.impl.jdbcjobstore.JobStoreSupport.replaceTrigger(JobStoreSupport.java:1474)
	at org.quartz.core.QuartzScheduler.rescheduleJob(QuartzScheduler.java:1121)
	at org.quartz.impl.StdScheduler.rescheduleJob(StdScheduler.java:321)
	at io.quarkus.quartz.runtime.QuartzSchedulerImpl.<init>(QuartzSchedulerImpl.java:294)
	at io.quarkus.quartz.runtime.QuartzSchedulerImpl_Bean.create(Unknown Source)
	at io.quarkus.quartz.runtime.QuartzSchedulerImpl_Bean.create(Unknown Source)
	at io.quarkus.arc.impl.AbstractSharedContext.createInstanceHandle(AbstractSharedContext.java:113)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:37)
	at io.quarkus.arc.impl.AbstractSharedContext$1.get(AbstractSharedContext.java:34)
	at io.quarkus.arc.impl.LazyValue.get(LazyValue.java:26)
	at io.quarkus.arc.impl.ComputingCache.computeIfAbsent(ComputingCache.java:69)
	at io.quarkus.arc.impl.AbstractSharedContext.get(AbstractSharedContext.java:34)
	at io.quarkus.quartz.runtime.QuartzSchedulerImpl_Observer_start_0f88b9afbe74c75c0e6959d7e0bd795b6582f6d3.notify(Unknown Source)
	at io.quarkus.arc.impl.EventImpl$Notifier.notifyObservers(EventImpl.java:326)
	at io.quarkus.arc.impl.EventImpl$Notifier.notify(EventImpl.java:308)
	at io.quarkus.arc.impl.EventImpl.fire(EventImpl.java:76)
	at io.quarkus.arc.runtime.ArcRecorder.fireLifecycleEvent(ArcRecorder.java:131)
        ...

```