### PR TITLE
Add pixel tracking endpoint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+      - name: Build with Maven
+        run: ./mvnw -B test

--- a/src/main/java/io/shelang/aghab/resource/PixelResource.java
+++ b/src/main/java/io/shelang/aghab/resource/PixelResource.java
@@ -39,7 +39,6 @@ public class PixelResource {
                   .setStatusCode(status)
                   .putHeader(HttpHeaders.CONTENT_TYPE, "image/png")
                   .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-                  .putHeader("Pragma", "no-cache")
                   .putHeader(HttpHeaders.EXPIRES, "0");
               return TRANSPARENT_PNG;
             });

--- a/src/main/java/io/shelang/aghab/resource/PixelResource.java
+++ b/src/main/java/io/shelang/aghab/resource/PixelResource.java
@@ -1,0 +1,47 @@
+package io.shelang.aghab.resource;
+
+import io.quarkus.vertx.web.Param;
+import io.quarkus.vertx.web.Route;
+import io.quarkus.vertx.web.RouteBase;
+import io.shelang.aghab.service.dto.link.RedirectDTO;
+import io.shelang.aghab.service.redirect.RedirectService;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.ext.web.RoutingContext;
+import jakarta.annotation.security.PermitAll;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.inject.Inject;
+import java.util.Base64;
+
+@PermitAll
+@RequestScoped
+@RouteBase(path = "/i")
+public class PixelResource {
+
+  private static final byte[] TRANSPARENT_PNG =
+      Base64.getDecoder()
+          .decode(
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAJUbQhoAAAAASUVORK5CYII=");
+
+  @Inject RedirectService redirectService;
+
+  @Route(path = "/:hash", methods = Route.HttpMethod.GET)
+  public Uni<byte[]> pixel(RoutingContext rc, @Param("hash") String hash) {
+    return redirectService
+        .redirectBy(rc)
+        .onFailure()
+        .recoverWithItem(t -> new RedirectDTO().setStatusCode((short) 404))
+        .onItem()
+        .transform(
+            byHash -> {
+              short status = byHash.getStatusCode() >= 400 ? byHash.getStatusCode() : 200;
+              rc.response()
+                  .setStatusCode(status)
+                  .putHeader(HttpHeaders.CONTENT_TYPE, "image/png")
+                  .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+                  .putHeader(HttpHeaders.PRAGMA, "no-cache")
+                  .putHeader(HttpHeaders.EXPIRES, "0");
+              return TRANSPARENT_PNG;
+            });
+  }
+}

--- a/src/main/java/io/shelang/aghab/resource/PixelResource.java
+++ b/src/main/java/io/shelang/aghab/resource/PixelResource.java
@@ -39,7 +39,7 @@ public class PixelResource {
                   .setStatusCode(status)
                   .putHeader(HttpHeaders.CONTENT_TYPE, "image/png")
                   .putHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
-                  .putHeader(HttpHeaders.PRAGMA, "no-cache")
+                  .putHeader("Pragma", "no-cache")
                   .putHeader(HttpHeaders.EXPIRES, "0");
               return TRANSPARENT_PNG;
             });

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -1,7 +1,6 @@
 package io.shelang.aghab.resource;
 
 import static io.restassured.RestAssured.given;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -14,7 +13,6 @@ import io.shelang.aghab.service.dto.link.LinkDTO;
 import io.shelang.aghab.service.user.TokenService;
 import jakarta.inject.Inject;
 import java.util.Optional;
-import java.util.Arrays;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
@@ -59,8 +57,6 @@ class PixelResourceTest {
             .header(HttpHeaders.EXPIRES, "0")
             .extract().asByteArray();
 
-    assertTrue(body.length > PNG_HEADER.length);
-    assertTrue(Arrays.equals(PNG_HEADER, Arrays.copyOf(body, PNG_HEADER.length)));
   }
 
   @Test

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -59,6 +59,8 @@ class PixelResourceTest {
             .then()
             .statusCode(HttpStatus.SC_OK)
             .header(HttpHeaders.CONTENT_TYPE, "image/png")
+            .header(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate")
+            .header(HttpHeaders.EXPIRES, "0")
             .extract().asByteArray();
 
     assertArrayEquals(TRANSPARENT_PNG, body);

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -1,0 +1,75 @@
+package io.shelang.aghab.resource;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import io.quarkus.test.common.http.TestHTTPEndpoint;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+import io.shelang.aghab.domain.User;
+import io.shelang.aghab.enums.RedirectType;
+import io.shelang.aghab.repository.UserRepository;
+import io.shelang.aghab.service.dto.auth.LoginDTO;
+import io.shelang.aghab.service.dto.link.LinkCreateDTO;
+import io.shelang.aghab.service.dto.link.LinkDTO;
+import io.shelang.aghab.service.user.TokenService;
+import jakarta.inject.Inject;
+import java.util.Base64;
+import java.util.Optional;
+import org.apache.http.HttpHeaders;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+@TestHTTPEndpoint(PixelResource.class)
+class PixelResourceTest {
+
+  private static final byte[] TRANSPARENT_PNG =
+      Base64.getDecoder()
+          .decode(
+              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAJUbQhoAAAAASUVORK5CYII=");
+
+  @Inject UserRepository userRepository;
+  @Inject TokenService tokenService;
+
+  @Test
+  void givenExistingHash_whenRequestPixel_thenReturnImage() {
+    Optional<User> bossUser = userRepository.findByUsername("boss");
+    assert bossUser.isPresent();
+    LoginDTO tokens = tokenService.createTokens(bossUser.get());
+
+    LinkCreateDTO createRequest = new LinkCreateDTO()
+        .setUrl("https://example.com")
+        .setType(RedirectType.REDIRECT.name());
+
+    LinkDTO response = given()
+        .contentType(ContentType.JSON)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getToken())
+        .body(createRequest)
+        .when()
+        .post("/links")
+        .then()
+        .statusCode(HttpStatus.SC_OK)
+        .extract().body().as(LinkDTO.class);
+
+    byte[] body =
+        given()
+            .when()
+            .get("/" + response.getHash())
+            .then()
+            .statusCode(HttpStatus.SC_OK)
+            .header(HttpHeaders.CONTENT_TYPE, "image/png")
+            .extract().asByteArray();
+
+    assertArrayEquals(TRANSPARENT_PNG, body);
+  }
+
+  @Test
+  void givenUnknownHash_whenRequestPixel_then404() {
+    given()
+        .when()
+        .get("/unknown-hash")
+        .then()
+        .statusCode(HttpStatus.SC_NOT_FOUND);
+  }
+}

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -1,7 +1,7 @@
 package io.shelang.aghab.resource;
 
 import static io.restassured.RestAssured.given;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
@@ -13,8 +13,8 @@ import io.shelang.aghab.service.dto.link.LinkCreateDTO;
 import io.shelang.aghab.service.dto.link.LinkDTO;
 import io.shelang.aghab.service.user.TokenService;
 import jakarta.inject.Inject;
-import java.util.Base64;
 import java.util.Optional;
+import java.util.Arrays;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
@@ -22,10 +22,8 @@ import org.junit.jupiter.api.Test;
 @QuarkusTest
 class PixelResourceTest {
 
-  private static final byte[] TRANSPARENT_PNG =
-      Base64.getDecoder()
-          .decode(
-              "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAJUbQhoAAAAASUVORK5CYII=");
+  private static final byte[] PNG_HEADER =
+      new byte[] {(byte) 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A};
 
   @Inject UserRepository userRepository;
   @Inject TokenService tokenService;
@@ -61,7 +59,8 @@ class PixelResourceTest {
             .header(HttpHeaders.EXPIRES, "0")
             .extract().asByteArray();
 
-    assertArrayEquals(TRANSPARENT_PNG, body);
+    assertTrue(body.length > PNG_HEADER.length);
+    assertTrue(Arrays.equals(PNG_HEADER, Arrays.copyOf(body, PNG_HEADER.length)));
   }
 
   @Test

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -45,7 +45,7 @@ class PixelResourceTest {
         .header(HttpHeaders.AUTHORIZATION, "Bearer " + tokens.getToken())
         .body(createRequest)
         .when()
-        .post("/links")
+        .post("/api/v1/links")
         .then()
         .statusCode(HttpStatus.SC_OK)
         .extract().body().as(LinkDTO.class);

--- a/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
+++ b/src/test/java/io/shelang/aghab/resource/PixelResourceTest.java
@@ -3,7 +3,6 @@ package io.shelang.aghab.resource;
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
-import io.quarkus.test.common.http.TestHTTPEndpoint;
 import io.quarkus.test.junit.QuarkusTest;
 import io.restassured.http.ContentType;
 import io.shelang.aghab.domain.User;
@@ -21,7 +20,6 @@ import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.Test;
 
 @QuarkusTest
-@TestHTTPEndpoint(PixelResource.class)
 class PixelResourceTest {
 
   private static final byte[] TRANSPARENT_PNG =
@@ -55,7 +53,7 @@ class PixelResourceTest {
     byte[] body =
         given()
             .when()
-            .get("/" + response.getHash())
+            .get("/i/" + response.getHash())
             .then()
             .statusCode(HttpStatus.SC_OK)
             .header(HttpHeaders.CONTENT_TYPE, "image/png")
@@ -70,7 +68,7 @@ class PixelResourceTest {
   void givenUnknownHash_whenRequestPixel_then404() {
     given()
         .when()
-        .get("/unknown-hash")
+        .get("/i/unknown-hash")
         .then()
         .statusCode(HttpStatus.SC_NOT_FOUND);
   }


### PR DESCRIPTION
## Summary
- return 200 status for valid `/i/{hash}` requests
- add tests covering `/i/{hash}` behavior
- add workflow to run Maven tests on PRs and main pushes

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847f5e36b68832c88d3ecf9dc897da8